### PR TITLE
Fix build problems on fresh checkout

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -10,6 +10,15 @@ npm install -g lerna # yarn global add lerna
 npm run dev:bootstrap # yarn dev:bootstrap
 ```
 
+### Compiling the code
+
+To compile the imba code to javascript, use the `build` script in the root
+directory:
+
+```
+npm run build
+```
+
 ###  Creating a Local Version
 
 While you can build your changes manually and copy over files into your

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,6 @@
   },
   "main": "dist/src/index.js",
   "scripts": {
-    "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "dependencies": {
     "vscode-languageclient": "^6.1.1"

--- a/package.json
+++ b/package.json
@@ -184,7 +184,9 @@
 	"scripts": {
 		"dev:bootstrap": "lerna bootstrap",
 		"watch": "imba watch",
-		"build": "imba build",
+		"build:client": "cd client && imba build -m -S src/index.imba",
+		"build:server": "cd server && imba build -m -S src/index.imba",
+		"build": "npm run build:client && npm run build:server",
 		"prod:version": "lerna version",
 		"build-theme": "imba scripts/compile-theme.imba",
 		"test": "node server/test.js"


### PR DESCRIPTION
The extension does not build from a fresh checkout on my Debian in WSL2q, due to two problems:

1. The `vscode` package is obsolete, and the postinstall script referenced in `client/package.json` does not exist anymore.
   See https://code.visualstudio.com/updates/v1_36#_splitting-vscode-package-into-typesvscode-and-vscodetest
   The typings are now provided by `@types/vscode`, so it is also unnecessary.
   This PR simply takes it out.

2. `npm run build` calls `imba build` which complains that no script file is given to build.
   This PR changes the build process so that the two child projects are built one-by-one and explicitly.

I have no experience with the code base, and with imba, so there may be a better way to achieve a working build on my machine, but these two changes worked so I could build a functioning VSIX by

```bash
npm dev:bootstrap
npm run build
vsce package
code --install-extension ./vsimba-*.vsix
```

Still to do:

- [x] Update `Development.md` to give all necessary build steps to build a working package